### PR TITLE
サイドバーの検索のショートカットを小文字から大文字に変更

### DIFF
--- a/iruka-code/src/app/(main)/_components/item.tsx
+++ b/iruka-code/src/app/(main)/_components/item.tsx
@@ -59,7 +59,7 @@ export const Item = ({
       <span className="truncate">{label}</span>
       {isSearch && (
         <kbd className="ml-auto pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
-          <span className="text-x">⌘</span>k
+          <span className="text-x">⌘</span>K
         </kbd>
       )}
     </div>


### PR DESCRIPTION
サイドバーの検索のショートカットを小文字から大文字に変更