### PR TITLE
サイドバーにチーム名を表示し、クリックすると画面遷移するように変更 サイドバーのチームタイトルの右のアイコンをクリックするとプロジェクト一覧が開くように変更

### DIFF
--- a/iruka-code/convex/teams.ts
+++ b/iruka-code/convex/teams.ts
@@ -1,15 +1,27 @@
 import { v } from 'convex/values';
 import { mutation, query } from './_generated/server';
 
-export const get = query({
-  handler: async (ctx) => {
+export const getSidebar = query({
+  args: {
+    project: v.optional(v.id('teams')),
+  },
+  handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
 
     if (!identity) {
       throw new Error('Not authenticated');
     }
 
-    const teams = await ctx.db.query('teams').collect();
+    const userId = identity.subject;
+
+    const teams = await ctx.db
+      .query('teams')
+      .withIndex('by_user_parent', (q) =>
+        q.eq('userId', userId).eq('project', args.project),
+      )
+      .filter((q) => q.eq(q.field('isArchived'), false))
+      .order('desc')
+      .collect();
 
     return teams;
   },

--- a/iruka-code/src/app/(main)/_components/item.tsx
+++ b/iruka-code/src/app/(main)/_components/item.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 import { Id } from '@convex/_generated/dataModel';
 import { ChevronDown, ChevronRight, LucideIcon } from 'lucide-react';
@@ -62,6 +63,18 @@ export const Item = ({
           <span className="text-x">⌘</span>K
         </kbd>
       )}
+    </div>
+  );
+};
+
+Item.Skeleton = function ItemSkeleton({ level }: { level?: number }) {
+  return (
+    <div
+      style={{ paddingLeft: level ? `${level * 12 + 25}px` : '12px' }}
+      className="flex gap-x-2 py-[3px]"
+    >
+      <Skeleton className="h-4 w-4" />
+      <Skeleton className="h-4 w-[30%]" />
     </div>
   );
 };

--- a/iruka-code/src/app/(main)/_components/item.tsx
+++ b/iruka-code/src/app/(main)/_components/item.tsx
@@ -30,6 +30,13 @@ export const Item = ({
   onExpand,
   expanded,
 }: ItemProps) => {
+  const handleExpand = (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+  ) => {
+    event.stopPropagation();
+    onExpand?.();
+  };
+
   const ChevronIcon = expanded ? ChevronDown : ChevronRight;
 
   return (
@@ -46,7 +53,7 @@ export const Item = ({
         <div
           role="button"
           className="h-full rounded-sm hover:bg-neutral-300 dark:bg-neutral-600 mr-1"
-          onClick={() => {}}
+          onClick={handleExpand}
         >
           <ChevronIcon className="h-4 w-4 shrink-0 text-muted-foreground/50" />
         </div>

--- a/iruka-code/src/app/(main)/_components/navigation.tsx
+++ b/iruka-code/src/app/(main)/_components/navigation.tsx
@@ -2,7 +2,7 @@
 
 import { cn } from '@/lib/utils';
 import { api } from '@convex/_generated/api';
-import { useMutation, useQuery } from 'convex/react';
+import { useMutation } from 'convex/react';
 import {
   ChevronsLeft,
   MenuIcon,
@@ -15,12 +15,12 @@ import { ElementRef, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useMediaQuery } from 'usehooks-ts';
 import { Item } from './item';
+import { TeamList } from './team-list';
 import { UserItem } from './user-item';
 
 export const Navigation = () => {
   const pathname = usePathname();
   const isMobile = useMediaQuery('(max-width: 768px)');
-  const teams = useQuery(api.teams.get);
   const create = useMutation(api.teams.create);
 
   const isResizingRef = useRef(false);
@@ -151,7 +151,7 @@ export const Navigation = () => {
           />
         </div>
         <div className="mt-4">
-          {teams?.map((team) => <p key={team._id}>{team.title}</p>)}
+          <TeamList />
         </div>
         <div
           onMouseDown={handleMouseDown}

--- a/iruka-code/src/app/(main)/_components/team-list.tsx
+++ b/iruka-code/src/app/(main)/_components/team-list.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { api } from '@convex/_generated/api';
+import { Doc, Id } from '@convex/_generated/dataModel';
+import { useQuery } from 'convex/react';
+import { FileIcon } from 'lucide-react';
+import { useParams, useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { Item } from './item';
+
+interface TeamListProps {
+  parentTeamId?: Id<'teams'>;
+  level?: number;
+  data?: Doc<'teams'>[];
+}
+
+export const TeamList = ({ parentTeamId, level = 0 }: TeamListProps) => {
+  const params = useParams();
+  const router = useRouter();
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  const onExpand = (teamId: string) => {
+    setExpanded((prevExpanded) => ({
+      ...prevExpanded,
+      [teamId]: !prevExpanded[teamId],
+    }));
+  };
+
+  const teams = useQuery(api.teams.getSidebar, {
+    project: parentTeamId,
+  });
+
+  const onRedirect = (teamId: string) => {
+    router.push(`/teams/${teamId}`);
+  };
+
+  if (teams === undefined) {
+    return (
+      <>
+        <Item.Skeleton level={level} />
+        {level === 0 && (
+          <>
+            <Item.Skeleton level={level} />
+            <Item.Skeleton level={level} />
+          </>
+        )}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <p
+        style={{ paddingLeft: level ? `${level * 12 + 25}px` : undefined }}
+        className={cn(
+          'hidden text-sm font-medium text-muted-foreground/80',
+          expanded && 'last:block',
+          level === 0 && 'hidden',
+        )}
+      >
+        プロジェクトがまだありません
+      </p>
+      {teams.map((team) => (
+        <div key={team._id}>
+          <Item
+            id={team._id}
+            onClick={() => onRedirect(team._id)}
+            label={team.title}
+            icon={FileIcon}
+            teamIcon={team.icon}
+            active={params.teamId === team._id}
+            level={level}
+            onExpand={() => onExpand(team._id)}
+            expanded={expanded[team._id]}
+          />
+          {expanded[team._id] && (
+            <TeamList parentTeamId={team._id} level={level + 1} />
+          )}
+        </div>
+      ))}
+    </>
+  );
+};

--- a/iruka-code/src/components/ui/skeleton.tsx
+++ b/iruka-code/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }


### PR DESCRIPTION
- **サイドバーにチーム名を表示し、クリックすると画面遷移するように変更**
- **サイドバーのチームタイトルの右のアイコンをクリックするとプロジェクト一覧が開くように変更**
